### PR TITLE
Refactor Tagging code to use lofty-rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 url
 playlist_json
+workdir_for_testing

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,48 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'musicfetch'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=musicfetch",
+                    "--package=musicfetch",
+                ],
+                "filter": {
+                    "name": "musicfetch",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "-f",
+                "/home/fried/Music/Death Grips/Exmilitary/5D.mp3"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'musicfetch'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=musicfetch",
+                    "--package=musicfetch"
+                ],
+                "filter": {
+                    "name": "musicfetch",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,10 +189,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "maplit",
- "ncurses",
  "signal-hook",
- "term_size",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -376,17 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id3"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46cd976185412abbe751da4d9e092223b078196751f73f947fe2cddd1255859"
-dependencies = [
- "bitflags",
- "byteorder",
- "flate2",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +459,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "lofty"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed685b48b30ef8f5213a32422d08c80b765f954ad5b6f6b634f901e7844ca52"
+dependencies = [
+ "base64",
+ "byteorder",
+ "cfg-if",
+ "flate2",
+ "lofty_attr",
+ "log",
+ "ogg_pager",
+ "once_cell",
+ "paste",
+]
+
+[[package]]
+name = "lofty_attr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336dfabb2fdfd932cebfcaa5d0fc57abac0d49f6ae9ddaa7c47a51bf9f74f966"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,24 +549,13 @@ dependencies = [
  "clap",
  "cursive",
  "dialoguer",
- "id3",
+ "lofty",
  "minreq",
  "regex",
  "sanitize-filename",
  "serde",
  "serde_json",
  "spinners",
-]
-
-[[package]]
-name = "ncurses"
-version = "5.101.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2c5d34d72657dc4b638a1c25d40aae81e4f1c699062f72f467237920752032"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -622,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ogg_pager"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d218a406e5de88e1c492d0162d569916f7436efe851ba5cc40a4bf4fa97cb40"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,10 +684,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.26"
+name = "paste"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "proc-macro-error"
@@ -973,16 +991,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "remove_dir_all",
- "winapi",
-]
-
-[[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -49,9 +49,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -61,9 +61,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -73,9 +73,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.29"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -101,25 +101,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -133,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -143,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -216,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -226,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -239,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
@@ -250,11 +249,12 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92e7e37ecef6857fdc0c0c5d42fd5b0938e46590c2183cc92dd310a6d078eb1"
+checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
 dependencies = [
  "console",
+ "shell-words",
  "tempfile",
  "zeroize",
 ]
@@ -267,9 +267,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enum-map"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c25992259941eb7e57b936157961b217a4fc8597829ddef0596d6c3cd86e1a"
+checksum = "988f0d17a0fa38291e5f41f71ea8d46a5d5497b9054d5a759fae2cbb819f2356"
 dependencies = [
  "enum-map-derive",
 ]
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -365,18 +365,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "ident_case"
@@ -395,37 +392,37 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -438,15 +435,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -461,12 +458,10 @@ dependencies = [
 [[package]]
 name = "lofty"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed685b48b30ef8f5213a32422d08c80b765f954ad5b6f6b634f901e7844ca52"
+source = "git+https://github.com/Serial-ATA/lofty-rs.git#33fb9a8c81ec6e7a10a4606caa12a5c0e8d29b77"
 dependencies = [
  "base64",
  "byteorder",
- "cfg-if",
  "flate2",
  "lofty_attr",
  "log",
@@ -532,14 +527,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -573,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
@@ -641,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "os_str_bytes"
@@ -672,22 +667,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "proc-macro-error"
@@ -715,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -730,9 +725,9 @@ checksum = "e9e1dcb320d6839f6edb64f7a4a59d39b30480d4d1765b56873f7c858538a5fe"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -748,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -762,15 +757,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "ring"
@@ -789,23 +775,23 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -815,15 +801,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "sanitize-filename"
@@ -853,18 +839,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -873,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -883,10 +869,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.14"
+name = "shell-words"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -905,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -971,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -982,42 +974,31 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "libc",
@@ -1035,24 +1016,24 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -1080,9 +1061,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1090,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -1105,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1115,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1128,15 +1109,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1208,46 +1189,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "xi-unicode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.0", features = ["derive"] }
-id3 = "1.5"
+lofty = "0.11"
 regex = "1.7"
 minreq = { version = "2.6.0", features = ["https", "punycode"] } 
 dialoguer = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ serde_json = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 lofty = { git = "https://github.com/Serial-ATA/lofty-rs.git" }
 regex = "1.7"
-minreq = { version = "2.6.0", features = ["https", "punycode"] } 
+minreq = { version = "2.6.0", features = ["https", "punycode"] }
 dialoguer = "*"
 spinners = "4.1.0"
 sanitize-filename = "0.4.0"
-cursive = { version = "0.20.0", features = ["crossterm-backend"], default-features = false }
+cursive = { version = "0.20.0", features = [
+    "crossterm-backend",
+], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "4.0", features = ["derive"] }
-lofty = "0.11"
+lofty = { git = "https://github.com/Serial-ATA/lofty-rs.git" }
 regex = "1.7"
 minreq = { version = "2.6.0", features = ["https", "punycode"] } 
 dialoguer = "*"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Musicfetch is a YouTube music downloader which allows you to interactively tag y
 
 This crate uses many experimental features because I like living on the edge and thus can only compiled with the nightly toolchain.
 
+## Notes
+- ID3v1 tags will be automatically upgraded to ID3v2
+
 ## Usage
     Usage: musicfetch [OPTIONS] <URL|--files <FILES>...|--yt-dlp-json <FILE>>
     

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Musicfetch
 Musicfetch is a YouTube music downloader which allows you to interactively tag your music. This project is engineered to fit my needs but it might just fit yours too. This tool probably isn't for you if you are an Audiophile. Songs are downloaded from Youtube as a 133 kb/s opus and then recoded to mp3. Most people (including me) won't notice but if you will don't bother with this tool (or open a PR/Suggest another way to get songs with better quality). You can also download from Bandcamp, then the songs will be 128 kb/s mp3's and won't need to be reencoded. 
 ### Description
-- Uses Id3v2.3 tags because 2.4 isn't supported anywhere
-    - Because of this multiple artists/genres aren't supported
 - Id3 frames supported:
     - Title
     - Album

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,81 @@
+tui for tagging
+man page
+Allow splitting album videos
+
+# Implement UI fully
+- Total Tracks field
+- Musicfetch banner
+
+# Ideas
+- Tokio, one thread for downloading/tagging etc and one for UI
+
+## Make the system more modular
+### The Dict, or 2 Dicts
+One dict with global values and one with values for each song. Maybe use Serde json values for the dict
+Song dict will look like this:
+```json
+"songs": [
+    {
+        "yt_dlp_values": {
+            ...
+        },
+        "tag_values": {
+            "title": "Never Gonna Give You Up",
+            "artist": "Rick Astley",
+        }
+    }
+]
+```
+Global dict will look like this:
+```json
+"args": [
+    ...
+]
+```
+### Workflow
+- Central Dict with values is passed to all modules
+- First there will be a list of urls in the dict
+- Then there may be a module that will download the yt-dlp jsons for all songs
+- Then a downloader module which also writes the filenames in the dict
+- Some more modules to edit the data
+- A tagging module which writes the tags to the files
+### Alternate Workflow
+- First the json downloader module will do it's thing
+- Since we now have all information the user can edit the data in the tui
+- after that the downloading of songs / tagging can happen
+this way the user doesn't have to wait for too long to edit
+
+### Ideas for modules:
+- jsonfetch: Inserts the yt-dlp json for each song into the dict
+- Yt-Title to Song Title
+- Custom script: Runs a user-specified script which will get the dict passed as json in stdin and needs to return the dict as json in the stdout
+- Song select: Remove certain songs that should not be downloaded
+
+### Parralelizing
+Problem: I want modules to be able to run in parallel but some modules require information from other modules
+
+#### Solution 1: Stages
+Each module will have dependencies on modules that need to run before they run. The user can specify which modules he wants to run in stages. It would look like this in the config file:
+```toml
+[stages]
+stage1 = ["jsonfetch"]
+stage2 = ["title-to-title"]
+stage3 = ["tagtui", "downloader"]
+stage4 = ["tagger"]
+```
+##### Pros:
+- Easy to configure & probably easier to implement
+- We can check the configurations at runtime and tell the user if any module dependencies aren't met
+##### Cons:
+- Each stage needs to be completed before the next stage can start
+    - While the downloader could theoretically start downloading right after the jsonfetch module has completed, it needs to wait for title-to-tile to finish
+        - Will probably be a non-issue since most modules don't take that long
+#### Solution 2: Figure out which modules can run at runtime
+Each module will run once it's dependencies are met, which means there will be no time wasted waiting
+##### Pros:
+- No wasted waiting time
+##### Cons:
+- Harder to implement
+- Probably harder to configure
+If two modules edit the same data, one needs to directly or indirectly depend on the other, otherwhise the order in which they are run could change from run to run.
+That means, if there are multiple inbuilt modules which modify the same data there needs to be a preconfigured dependency tree so that they run in the same order every time. If the user now wants to edit the order they will run in he needs to rewrite the dependencies for all these modules.

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,3 +1,0 @@
-ncurses ui for tagging
-man page
-Allow splitting album videos

--- a/src/download.rs
+++ b/src/download.rs
@@ -5,7 +5,8 @@ use std::str;
 
 use spinners::{Spinner, Spinners};
 
-const YT_DLP_ARGS: [&str; 8] = [
+const YT_DLP_ARGS: [&str; 9] = [
+    "--ignore-config",
     "-x",
     "-f",
     "ba",
@@ -27,10 +28,9 @@ pub fn fetch_yt_dlp_json(url: &str) -> Result<String, Box<dyn Error>> {
 
     sp.stop_with_newline();
 
-    // Check if command ran correctly
-    json_output.status.exit_ok()?;
-
-    Ok(String::from_utf8(json_output.stdout)?)
+    Ok(String::from_utf8(json_output.stdout).expect(
+        "Could not parse the yt-dlp json. The yt-dlp command probably didn't run correctly",
+    ))
 }
 
 pub fn download_song(yt_dlp_json: &str, dir: &str) -> Result<String, Box<dyn Error>> {
@@ -48,7 +48,7 @@ pub fn download_song(yt_dlp_json: &str, dir: &str) -> Result<String, Box<dyn Err
         .as_mut()
         .expect("Failed to write to yt-dlp stdin");
     stdin.write(&yt_dlp_json.as_bytes())?;
-    download_process.wait()?.exit_ok().expect("Download failed");
+    download_process.wait()?.exit_ok()?;
 
     // Return path of downloaded file
     Ok(get_downloaded_filename(&yt_dlp_json)?)

--- a/src/download.rs
+++ b/src/download.rs
@@ -18,7 +18,7 @@ const YT_DLP_ARGS: [&str; 9] = [
 ];
 
 pub fn fetch_yt_dlp_json(url: &str) -> Result<String, Box<dyn Error>> {
-    let mut sp = Spinner::new(Spinners::Line, "Fetching Song/Playlist info. For playlists this can take a while depending on your internet speed.".into());
+    let mut sp = Spinner::new(Spinners::Line, "Fetching Song/Playlist info.".into());
     let json_output = Command::new("yt-dlp")
         .arg("-J")
         .arg(&url)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(exit_status_error)]
 #![feature(default_free_fn)]
 #![feature(let_chains)]
+#![feature(is_some_and)]
 
 use std::default::default;
 use std::error::Error;

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -12,7 +12,7 @@ pub struct Song {
     pub song_metadata: SongMetadata,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Default, Clone, Eq, PartialEq)]
 pub struct SongMetadata {
     pub fulltitle: String,
     #[serde(rename = "track")]
@@ -56,6 +56,14 @@ pub struct Playlist {
 
 impl From<&Song> for String {
     fn from(value: &Song) -> Self {
+        if value
+            .song_metadata
+            .title
+            .as_ref()
+            .is_some_and(|s| !s.is_empty())
+        {
+            return value.song_metadata.title.clone().unwrap();
+        }
         value.song_metadata.fulltitle.clone()
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,14 +1,13 @@
 use std::path::PathBuf;
 
-use id3::Tag;
+use lofty::Tag;
 
 use serde::Deserialize;
 use serde_json::Value;
 
-#[derive(Debug)]
 pub struct Song {
     pub path: PathBuf,
-    pub tag: Option<Tag>,
+    pub tag: Tag,
     pub song_metadata: SongMetadata,
 }
 
@@ -20,7 +19,7 @@ pub struct SongMetadata {
     pub album: Option<String>,
     pub artist: Option<String>,
     #[serde(default, rename = "release_year")]
-    pub year: Option<i32>,
+    pub year: Option<u32>,
     #[serde(skip)]
     pub genre: Option<String>,
     #[serde(skip)]
@@ -44,7 +43,7 @@ impl SongMetadata {
 pub struct AlbumMetadata {
     pub album_title: String,
     pub artist: String,
-    pub year: i32,
+    pub year: u32,
     pub genre: String,
 }
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -5,13 +5,14 @@ use lofty::Tag;
 use serde::Deserialize;
 use serde_json::Value;
 
+#[derive(Clone)]
 pub struct Song {
     pub path: PathBuf,
     pub tag: Tag,
     pub song_metadata: SongMetadata,
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub struct SongMetadata {
     pub fulltitle: String,
     #[serde(rename = "track")]
@@ -51,4 +52,10 @@ pub struct AlbumMetadata {
 pub struct Playlist {
     pub title: String,
     pub entries: Vec<Value>,
+}
+
+impl From<&Song> for String {
+    fn from(value: &Song) -> Self {
+        value.song_metadata.fulltitle.clone()
+    }
 }

--- a/src/tagging.rs
+++ b/src/tagging.rs
@@ -203,6 +203,37 @@ pub fn tag_songs_tui(songs: &mut Vec<Song>) {
                         get_song_metadata_layout(&songs[0]),
                     )),
             )
+            .child(
+                LinearLayout::horizontal()
+                    .child(DummyView.full_width())
+                    .child(TextView::new("Total Tracks:"))
+                    .child(DummyView.fixed_width(11))
+                    .child(
+                        EditView::new()
+                            .content(
+                                songs[0].song_metadata.total_tracks.unwrap_string()
+                            )
+                            .on_edit(|siv, text, _cursor| {
+                                let total_tracks = text
+                                    .chars()
+                                    .filter(|c| c.is_ascii_digit())
+                                    .fold(String::new(), |x, y| x + &y.to_string());
+                                
+                                siv.call_on_name("total_tracks", |view: &mut EditView| {
+                                    view.set_content(&total_tracks);
+                                });
+                                
+                                siv.call_on_name("songlist", |v: &mut SelectView<Song>| {
+                                    for (_lbl, song) in v.iter_mut() {
+                                        song.song_metadata.total_tracks = total_tracks.parse::<u32>().ok();
+                                    }
+                                });
+                            })
+                            .with_name("total_tracks")
+                            .fixed_width(8)
+                    )
+                    .fixed_width(65),
+            )
             .child(Button::new("Save", |siv| siv.quit())),
     ));
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,10 @@
+use crate::structs::Song;
+use crate::tagging::UnwrapString;
 use cursive::{
+    direction::Direction,
     view::{Nameable, Resizable},
-    views::{DummyView, EditView, LinearLayout, ResizedView, TextView},
+    views::{DummyView, EditView, LinearLayout, ResizedView, SelectView, TextView},
+    Cursive, View,
 };
 
 pub fn get_album_metadata_layout() -> LinearLayout {
@@ -28,34 +32,142 @@ pub fn get_album_metadata_layout() -> LinearLayout {
         .child(EditView::new().with_name("genre"))
 }
 
-pub fn get_song_metadata_layout(first_title: &str) -> LinearLayout {
+macro_rules! set_song_data {
+    ($siv:expr, $field:ident, $content:expr) => {
+        $siv.call_on_name("songlist", |v: &mut SelectView<Song>| {
+            let Some(selected) = v.selected_id() else { return; };
+            let Some((_label, song)) = v.get_item_mut(selected) else { return; };
+            song.song_metadata.$field = $content;
+        })
+        .unwrap();
+    };
+}
+
+pub fn get_song_metadata_layout(first_song: &Song) -> LinearLayout {
     LinearLayout::vertical()
         .child(ResizedView::with_fixed_height(
             3,
-            TextView::new(first_title).center().with_name("title_text"),
+            TextView::new(&String::from(first_song))
+                .center()
+                .with_name("title_text"),
         ))
         .child(DummyView.fixed_height(1))
         .child(TextView::new("Title"))
-        .child(EditView::new().with_name("title"))
+        .child(
+            EditView::new()
+                .content(first_song.song_metadata.title.clone().unwrap_or_default())
+                .on_edit(|siv, text, _cursor| {
+                    set_song_data!(siv, title, Some(text.to_string()));
+                    // Refresh here to show title changes in the list
+                    refresh_songlist(siv);
+                })
+                .with_name("title"),
+        )
         .child(TextView::new("Album"))
-        .child(EditView::new().with_name("album"))
+        .child(
+            EditView::new()
+                .content(first_song.song_metadata.album.clone().unwrap_or_default())
+                .on_edit(|siv, text, _cursor| {
+                    set_song_data!(siv, album, Some(text.to_string()));
+                })
+                .with_name("album"),
+        )
         .child(TextView::new("Artist"))
-        .child(EditView::new().with_name("artist"))
+        .child(
+            EditView::new()
+                .content(first_song.song_metadata.artist.clone().unwrap_or_default())
+                .on_edit(|siv, text, _cursor| {
+                    set_song_data!(siv, artist, Some(text.to_string()));
+                })
+                .with_name("artist"),
+        )
         .child(TextView::new("Year"))
         .child(
             EditView::new()
-                .on_edit(|s, t, _| {
-                    s.call_on_name("year", |view: &mut EditView| {
-                        view.set_content(
-                            t.chars()
-                                .filter(|c| c.is_ascii_digit())
-                                .take(4)
-                                .fold(String::new(), |x, y| x + &y.to_string()),
-                        );
+                .on_edit(|siv, t, _| {
+                    let year = t
+                        .chars()
+                        .filter(|c| c.is_ascii_digit())
+                        .take(4)
+                        .fold(String::new(), |x, y| x + &y.to_string());
+                    siv.call_on_name("year", |view: &mut EditView| {
+                        view.set_content(&year);
                     });
+                    set_song_data!(siv, year, year.parse::<u32>().ok());
                 })
+                .content(first_song.song_metadata.year.clone().unwrap_string())
                 .with_name("year"),
         )
         .child(TextView::new("Genre"))
-        .child(EditView::new().with_name("genre"))
+        .child(
+            EditView::new()
+                .content(first_song.song_metadata.genre.clone().unwrap_or_default())
+                .on_edit(|siv, text, _cursor| {
+                    set_song_data!(siv, genre, Some(text.to_string()));
+                })
+                .with_name("genre"),
+        )
+        .child(DummyView.fixed_height(1))
+        .child(
+            LinearLayout::horizontal()
+                .child(TextView::new("Track No:").max_width(9))
+                .child(DummyView.full_width())
+                .child(
+                    EditView::new()
+                        .content(first_song.song_metadata.track_no.clone().unwrap_string())
+                        .on_edit(|siv, text, _cursor| {
+                            let track = text
+                                .chars()
+                                .filter(|c| c.is_ascii_digit())
+                                .fold(String::new(), |x, y| x + &y.to_string());
+                            siv.call_on_name("track", |view: &mut EditView| {
+                                view.set_content(&track);
+                            });
+                            set_song_data!(siv, track_no, track.parse::<u32>().ok());
+                            refresh_songlist(siv);
+                        })
+                        .on_submit(|siv, _text| {
+                            siv.focus_name("songlist").unwrap();
+                        })
+                        .with_name("track")
+                        .fixed_width(8),
+                )
+                .full_width(),
+        )
+}
+
+fn refresh_songlist(siv: &mut Cursive) {
+    siv.call_on_name("songlist", |v: &mut SelectView<Song>| {
+        // Get the currently selected song
+        let sel = v
+            .selection()
+            .expect("Either the list of songs is empty or something has gone horribly wrong");
+
+        v.sort_by(|s, t| {
+            s.song_metadata
+                .track_no
+                .unwrap_or(u32::MAX)
+                .cmp(&t.song_metadata.track_no.unwrap_or(u32::MAX))
+        });
+        for (label, song) in v.iter_mut() {
+            label.remove_spans(0..1);
+            label.compact();
+            label.append(format!(
+                "{} {}",
+                song.song_metadata.track_no.unwrap_string(),
+                String::from(&song.to_owned())
+            ));
+        }
+
+        // Find the position of the edited song after the sort
+        let pos = v
+            .iter()
+            .position(|(_itm, song)| song.path == sel.as_ref().path);
+        // If the song is found, select it. If not give focus to the SelectView
+        if let Some(pos) = pos {
+            v.set_selection(pos);
+        } else {
+            v.take_focus(Direction::none()).unwrap();
+        }
+    });
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,11 +1,43 @@
 use cursive::{
-    view::Nameable,
-    views::{EditView, LinearLayout, TextView},
+    view::{Nameable, Resizable},
+    views::{DummyView, EditView, LinearLayout, ResizedView, TextView},
 };
 
 pub fn get_album_metadata_layout() -> LinearLayout {
     LinearLayout::vertical()
         .child(TextView::new("Album Title"))
+        .child(EditView::new().with_name("album"))
+        .child(TextView::new("Artist"))
+        .child(EditView::new().with_name("artist"))
+        .child(TextView::new("Year"))
+        .child(
+            EditView::new()
+                .on_edit(|s, t, _| {
+                    s.call_on_name("year", |view: &mut EditView| {
+                        view.set_content(
+                            t.chars()
+                                .filter(|c| c.is_ascii_digit())
+                                .take(4)
+                                .fold(String::new(), |x, y| x + &y.to_string()),
+                        );
+                    });
+                })
+                .with_name("year"),
+        )
+        .child(TextView::new("Genre"))
+        .child(EditView::new().with_name("genre"))
+}
+
+pub fn get_song_metadata_layout(first_title: &str) -> LinearLayout {
+    LinearLayout::vertical()
+        .child(ResizedView::with_fixed_height(
+            3,
+            TextView::new(first_title).center().with_name("title_text"),
+        ))
+        .child(DummyView.fixed_height(1))
+        .child(TextView::new("Title"))
+        .child(EditView::new().with_name("title"))
+        .child(TextView::new("Album"))
         .child(EditView::new().with_name("album"))
         .child(TextView::new("Artist"))
         .child(EditView::new().with_name("artist"))


### PR DESCRIPTION
This is currently only a draft since lofty currently only supports writing ID3v2.4 tags. This project primarily uses ID3v2.3 because of the better software support. This will be merged once a solution is found to write v2.3 tags. This could be achieved by either:
- Lofty-rs supporting ID3v2.3 writing (preferred)
- converting the tag to ID3v2.3 after writing

The second would be a dirty hack which I don't really want to include. I might look into contributing ID3v2.3 support to lofty-rs